### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@
 
 ## Setting up the Environment
 
-In order to set up the development environment, you first have to install all requirements of this project in a local virtual environment:
+In order to set up the development environment for the first time, you have to install the local virtual environment once by *sourcing* the `env.sh` script:
+
+```
+. ./env.sh
+```
+
+You have to install all requirements of this project in a local virtual environment:
 
 ```
 make requirements
@@ -13,7 +19,7 @@ make requirements
 
 You need to do this (normally) only once, unless a new dependency on a Python package was introduced.
 
-Once the local virtual environment is installed, you can activate it by *sourcing* the `env.sh` script:
+Once the local virtual environment is installed, you can simply activate it by *sourcing* the `env.sh` script:
 
 ```
 . ./env.sh


### PR DESCRIPTION
Tried to highlight that 'make requirements' should be called within an activated virtual environment otherwise you might run in a 'permission denied' situation. Still open env.sh uses pyvenv to install/create the virtual environment. pyvenv should be version independent.